### PR TITLE
Redesign profile with polished layout, real content, and new SVG graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,191 @@
-# Sean Vasey
+<div align="center">
 
-![VASEY/AI banner](assets/banner.svg)
+![Sean Vasey — AI + Media Development](assets/banner.svg)
 
-![VASEY/AI](https://img.shields.io/badge/VASEY%2FAI-creative%20tools-10c7d8?style=for-the-badge) ![Vasey Multimedia](https://img.shields.io/badge/Vasey%20Multimedia-audio%20%26%20music-0aa6c2?style=for-the-badge)
+[![VASEY/AI](https://img.shields.io/badge/VASEY%2FAI-creative_tools-0ef0ff?style=for-the-badge&labelColor=0d1520)](https://vaseyai.com)&nbsp;
+[![Vasey Multimedia](https://img.shields.io/badge/Vasey_Multimedia-audio_%26_production-2ec4b6?style=for-the-badge&labelColor=0d1520)](https://vasey.audio)
 
-![Prompt Engineering](https://img.shields.io/badge/Prompt_Engineering-studio-00bcd4?style=flat-square) ![AI / LLM](https://img.shields.io/badge/AI-LLM%20tooling-2aa7ff?style=flat-square) ![Media](https://img.shields.io/badge/Media-creative%20tech-2ec4b6?style=flat-square) ![PWA](https://img.shields.io/badge/PWA-mobile%20first-0b7285?style=flat-square)
+<br>
 
-![JavaScript](https://img.shields.io/badge/JavaScript-ESNext-f7df1e?style=flat-square&logo=javascript&logoColor=000) ![TypeScript](https://img.shields.io/badge/TypeScript-TS-3178c6?style=flat-square&logo=typescript&logoColor=fff) ![HTML5](https://img.shields.io/badge/HTML5-markup-e34f26?style=flat-square&logo=html5&logoColor=fff) ![CSS3](https://img.shields.io/badge/CSS3-styling-1572b6?style=flat-square&logo=css3&logoColor=fff)
+**`AI & media developer building design-forward creative tools, prompt engineering systems, and interactive audio experiences.`**
 
-AI & media developer focused on creative tooling, prompt engineering, and interactive audio/visual experiences. This profile centers on **VASEY/AI** and **Vasey Multimedia**, with active work in AI-assisted creation, media utilities, and music production.
+<br>
 
-**Contact:** sean@vaseyai.com
+[![Email](https://img.shields.io/badge/sean@vaseyai.com-0d1520?style=flat-square&logo=gmail&logoColor=0ef0ff)](mailto:sean@vaseyai.com)&nbsp;
+[![X](https://img.shields.io/badge/@SeannyV-0d1520?style=flat-square&logo=x&logoColor=fff)](https://x.com/SeannyV)&nbsp;
+[![Instagram](https://img.shields.io/badge/@vasey.audio-0d1520?style=flat-square&logo=instagram&logoColor=E4405F)](https://instagram.com/vasey.audio)&nbsp;
+[![SoundCloud](https://img.shields.io/badge/SoundCloud-0d1520?style=flat-square&logo=soundcloud&logoColor=FF5500)](https://soundcloud.com/seanvasey)&nbsp;
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0d1520?style=flat-square&logo=linkedin&logoColor=0A66C2)](https://linkedin.com/in/seanvasey)&nbsp;
+[![Portfolio](https://img.shields.io/badge/seanvasey.link-0d1520?style=flat-square&logo=linktree&logoColor=43E55E)](https://seanvasey.link)
 
-## Profile Blurb
-I build practical, design-forward tools that blend AI with media workflows—from prompt engineering studios to fast, mobile-ready utilities. I also develop music production tools and experiments under **Vasey Multimedia**, with an emphasis on accessible, creative instruments and audio tooling.
+</div>
 
-## Enterprises & Focus
-- **VASEY/AI** — AI-assisted media tools, prompt systems, and creative automation.
-- **Vasey Multimedia** — music production tools, instruments, and interactive audio experiences.
+<br>
 
-## Apps & Projects
-Status reflects known deployed URLs (Vercel/GitHub Pages) and active development.
+<img src="assets/divider.svg" width="100%" alt="">
 
-| Preview | Project | Description | Status | Live | Repo |
-| --- | --- | --- | --- | --- | --- |
-| ![StyleyeS preview](assets/placeholders/styleyes.svg) | **StyleyeS** | Vivid prompt engineering studio for AI image generation with curated styles and controls. | Deployed | https://styleyes.vercel.app | https://github.com/SeanVasey/StyleyeS |
-| ![rePROMPT preview](assets/placeholders/reprompt.svg) | **rePROMPT** | AI prompt enhancer that refines and expands prompts for richer, more detailed outputs. | Deployed | https://reprompt.vercel.app | https://github.com/SeanVasey/rePROMPT |
-| ![FilePhile preview](assets/placeholders/filephile.svg) | **FilePhile** | File generation studio for creating, editing, and exporting documents in multiple formats. | Deployed | https://filephile.vercel.app | https://github.com/SeanVasey/FilePhile |
-| ![reSOURCERY preview](assets/placeholders/resourcery.svg) | **reSOURCERY** | Fast media extraction and conversion tool for pulling audio and video from web sources. | Deployed | https://resourcery.vercel.app | https://github.com/SeanVasey/reSOURCERY |
-| ![VASEYSPACE preview](assets/placeholders/vaseyspace.svg) | **VASEYSPACE** | ISS tracking and naked-eye visibility observer. | Deployed (GitHub Pages) | https://seanvasey.github.io/VASEYSPACE | https://github.com/SeanVasey/VASEYSPACE |
-| ![DULLAH80s preview](assets/placeholders/dullah80s.svg) | **DULLAH80s** | Mobile-ready 80s drum synth and sequencer. | Deployed (GitHub Pages) | https://seanvasey.github.io/DULLAH80s | https://github.com/SeanVasey/DULLAH80s |
+## About
 
-## Now Building (Auto-updated)
-<!-- NOW_BUILDING_START -->
-**Automated feed placeholder.**
-- This section updates from `now-building` labeled issues across repositories.
-- It also highlights the most recently updated active repo with frequent commits.
-- If multiple projects are active, the top two are shown.
+I design and ship practical tools that sit at the intersection of **AI** and **media**—prompt engineering studios, file utilities, media extraction pipelines, and browser-based instruments. Everything I build is mobile-first, PWA-ready, and deployed live.
 
-> Manual fallback: update the Roadmap section below with dates, milestone notes, and release targets.
-<!-- NOW_BUILDING_END -->
+Outside of code, I produce music and develop audio experiences under **Vasey Multimedia**, bringing 20+ years of creative arts experience into everything I ship.
 
-## Roadmap & Milestones (Fill in)
-Use the placeholders below to add milestone notes, projected completion dates, and major updates.
+<img src="assets/divider.svg" width="100%" alt="">
 
-### StyleyeS
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+## Enterprises
 
-### rePROMPT
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+<table>
+<tr>
+<td width="50%" valign="top">
 
-### FilePhile
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+### ⚡ VASEY/AI
+AI-assisted media tools and creative automation. Focused on prompt engineering systems, LLM-powered utilities, and tools that make AI accessible for creators.
 
-### reSOURCERY
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+**Focus areas:** Prompt engineering · AI image generation · File utilities · Media extraction · Creative automation
 
-### VASEYSPACE
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+</td>
+<td width="50%" valign="top">
 
-### DULLAH80s
-- **Current phase:** [placeholder]
-- **Projected release:** [placeholder]
-- **Milestones:**
-  - [placeholder]
-  - [placeholder]
-  - [placeholder]
+### 🎵 Vasey Multimedia
+Music production tools, interactive instruments, and audio experiences. Building browser-based creative instruments that are accessible on any device.
+
+**Focus areas:** Audio synthesis · Drum machines · Music production · Sound design · Interactive audio
+
+</td>
+</tr>
+</table>
+
+<img src="assets/divider.svg" width="100%" alt="">
+
+## Projects
+
+> All projects are live and deployed. Click any preview to visit the app.
+
+<br>
+
+<table>
+<tr>
+<td align="center" width="33%">
+<a href="https://styleyes.vercel.app">
+<img src="assets/placeholders/styleyes.svg" width="280" alt="StyleyeS" /><br>
+<strong>StyleyeS</strong>
+</a><br>
+<sub>Prompt engineering studio for AI image generation. Curated style presets, real-time prompt construction, and visual controls for crafting vivid image prompts.</sub><br><br>
+<a href="https://styleyes.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/StyleyeS"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+<td align="center" width="33%">
+<a href="https://reprompt.vercel.app">
+<img src="assets/placeholders/reprompt.svg" width="280" alt="rePROMPT" /><br>
+<strong>rePROMPT</strong>
+</a><br>
+<sub>AI prompt enhancer that refines, expands, and optimizes prompts for richer, more detailed outputs from any LLM or image model.</sub><br><br>
+<a href="https://reprompt.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/rePROMPT"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+<td align="center" width="33%">
+<a href="https://filephile.vercel.app">
+<img src="assets/placeholders/filephile.svg" width="280" alt="FilePhile" /><br>
+<strong>FilePhile</strong>
+</a><br>
+<sub>File generation studio for creating, editing, and exporting documents. Supports TXT, Markdown, JSON, CSV, HTML and more—all in-browser.</sub><br><br>
+<a href="https://filephile.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/FilePhile"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+</tr>
+<tr><td colspan="3">&nbsp;</td></tr>
+<tr>
+<td align="center" width="33%">
+<a href="https://resourcery.vercel.app">
+<img src="assets/placeholders/resourcery.svg" width="280" alt="reSOURCERY" /><br>
+<strong>reSOURCERY</strong>
+</a><br>
+<sub>Fast media extraction and conversion tool. Pull audio and video from web sources, convert between formats, and download—no installs needed.</sub><br><br>
+<a href="https://resourcery.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/reSOURCERY"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+<td align="center" width="33%">
+<a href="https://seanvasey.github.io/VASEYSPACE">
+<img src="assets/placeholders/vaseyspace.svg" width="280" alt="VASEYSPACE" /><br>
+<strong>VASEYSPACE</strong>
+</a><br>
+<sub>Real-time ISS tracker and naked-eye visibility observer. Shows the station's live position, pass predictions, and best viewing windows for your location.</sub><br><br>
+<a href="https://seanvasey.github.io/VASEYSPACE"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/VASEYSPACE"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+<td align="center" width="33%">
+<a href="https://seanvasey.github.io/DULLAH80s">
+<img src="assets/placeholders/dullah80s.svg" width="280" alt="DULLAH80s" /><br>
+<strong>DULLAH80s</strong>
+</a><br>
+<sub>Mobile-ready 80s drum synthesizer and step sequencer. Classic drum machine sounds with a modern interface—play, sequence, and perform right in the browser.</sub><br><br>
+<a href="https://seanvasey.github.io/DULLAH80s"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
+<a href="https://github.com/SeanVasey/DULLAH80s"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
+</td>
+</tr>
+</table>
+
+<img src="assets/divider.svg" width="100%" alt="">
 
 ## Tech Stack
-- **AI/LLM tooling:** Prompt engineering, creative automation
-- **Web:** JavaScript, TypeScript, HTML, CSS
-- **UX:** Mobile-first, PWA-ready experiences
-- **Media:** Audio tooling, sequencing, interactive music utilities
 
-## Featured Media
-- StyleyeS (Prompt studio): https://styleyes.vercel.app
-- rePROMPT (Prompt enhancer): https://reprompt.vercel.app
-- DULLAH80s (Drum synth): https://seanvasey.github.io/DULLAH80s
+<div align="center">
 
-## GitHub Highlights
-- Pinned repos: StyleyeS, rePROMPT, FilePhile, reSOURCERY, VASEYSPACE, DULLAH80s
-- Add GitHub profile README images (app previews or banners) for quick visual context
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=000)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=fff)
+![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=fff)
+![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=fff)
+![Vercel](https://img.shields.io/badge/Vercel-000?style=for-the-badge&logo=vercel&logoColor=fff)
+![GitHub Pages](https://img.shields.io/badge/GitHub_Pages-222?style=for-the-badge&logo=github&logoColor=fff)
 
-## GitHub Profile Best Practices (Applied)
-- Clear, focused bio and mission statement
-- Enterprise context and creative focus areas
-- Live product links + repositories
-- Direct contact email
+</div>
 
-## Notes
-If any GitHub Pages links need corrections, let me know and I'll update them to match the configured Pages URLs.
+| Domain | Tools & Technologies |
+| --- | --- |
+| **AI / LLM** | Prompt engineering, LLM integration, creative automation, AI image generation workflows |
+| **Frontend** | JavaScript (ESNext), TypeScript, HTML5, CSS3, responsive design |
+| **Architecture** | PWA-first, mobile-ready, offline-capable, single-page apps |
+| **Audio** | Web Audio API, synthesis, sequencing, sample-based instruments |
+| **Deployment** | Vercel, GitHub Pages, CI/CD workflows |
+
+<img src="assets/divider.svg" width="100%" alt="">
+
+## Current Focus
+
+```
+ ╔══════════════════════════════════════════════════════════════╗
+ ║  → Expanding StyleyeS with new style presets & model        ║
+ ║    support for next-gen image generators                     ║
+ ║  → Building rePROMPT v2 with multi-model prompt             ║
+ ║    optimization and comparison workflows                    ║
+ ║  → Improving reSOURCERY extraction pipeline for broader     ║
+ ║    format support and faster conversions                    ║
+ ║  → Exploring new browser-based audio tools under            ║
+ ║    Vasey Multimedia                                         ║
+ ╚══════════════════════════════════════════════════════════════╝
+```
+
+<img src="assets/divider.svg" width="100%" alt="">
+
+<div align="center">
+
+## GitHub Stats
+
+<img src="https://github-readme-stats.vercel.app/api?username=SeanVasey&show_icons=true&theme=transparent&title_color=0ef0ff&text_color=7fbfca&icon_color=2ec4b6&border_color=1a2a3a&hide_border=false&bg_color=0d1520" width="49%" alt="GitHub Stats">
+<img src="https://github-readme-streak-stats.herokuapp.com?user=SeanVasey&theme=transparent&ring=0ef0ff&fire=2ec4b6&currStreakLabel=0ef0ff&sideLabels=7fbfca&dates=4a7a85&border=1a2a3a&background=0d1520" width="49%" alt="GitHub Streak">
+
+</div>
+
+<br>
+
+<div align="center">
+
+![Footer](assets/footer.svg)
+
+<sub>
+
+**[vaseyai.com](https://vaseyai.com)** · **[vasey.audio](https://vasey.audio)** · **[seanvasey.link](https://seanvasey.link)**
+
+</sub>
+
+</div>

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@
 [![Email](https://img.shields.io/badge/sean@vaseyai.com-0d1520?style=flat-square&logo=gmail&logoColor=0ef0ff)](mailto:sean@vaseyai.com)&nbsp;
 [![X](https://img.shields.io/badge/@SeannyV-0d1520?style=flat-square&logo=x&logoColor=fff)](https://x.com/SeannyV)&nbsp;
 [![Instagram](https://img.shields.io/badge/@vasey.audio-0d1520?style=flat-square&logo=instagram&logoColor=E4405F)](https://instagram.com/vasey.audio)&nbsp;
-[![SoundCloud](https://img.shields.io/badge/SoundCloud-0d1520?style=flat-square&logo=soundcloud&logoColor=FF5500)](https://soundcloud.com/seanvasey)&nbsp;
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0d1520?style=flat-square&logo=linkedin&logoColor=0A66C2)](https://linkedin.com/in/seanvasey)&nbsp;
+[![SoundCloud](https://img.shields.io/badge/SoundCloud-0d1520?style=flat-square&logo=soundcloud&logoColor=FF5500)](https://soundcloud.com/vaseyaudio)&nbsp;
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0d1520?style=flat-square&logo=linkedin&logoColor=0A66C2)](https://linkedin.com/in/seanmvasey)&nbsp;
+[![YouTube](https://img.shields.io/badge/YouTube-0d1520?style=flat-square&logo=youtube&logoColor=FF0000)](https://youtube.com/channel/UCgr3dcoFkHMHAiG9hacNbTg)&nbsp;
+[![Bluesky](https://img.shields.io/badge/Bluesky-0d1520?style=flat-square&logo=bluesky&logoColor=0085FF)](https://bsky.app/profile/vasey.audio)&nbsp;
 [![Portfolio](https://img.shields.io/badge/seanvasey.link-0d1520?style=flat-square&logo=linktree&logoColor=43E55E)](https://seanvasey.link)
 
 </div>
@@ -47,9 +49,9 @@ AI-assisted media tools and creative automation. Focused on prompt engineering s
 <td width="50%" valign="top">
 
 ### 🎵 Vasey Multimedia
-Music production tools, interactive instruments, and audio experiences. Building browser-based creative instruments that are accessible on any device.
+Music production, interactive instruments, and audio experiences. From browser-based drum machines to beat production and mixing/mastering services at [vasey.audio](https://vasey.audio).
 
-**Focus areas:** Audio synthesis · Drum machines · Music production · Sound design · Interactive audio
+**Focus areas:** Audio synthesis · Drum machines · Beat production · Sound design · Mixing & mastering
 
 </td>
 </tr>
@@ -70,7 +72,7 @@ Music production tools, interactive instruments, and audio experiences. Building
 <img src="assets/placeholders/styleyes.svg" width="280" alt="StyleyeS" /><br>
 <strong>StyleyeS</strong>
 </a><br>
-<sub>Prompt engineering studio for AI image generation. Curated style presets, real-time prompt construction, and visual controls for crafting vivid image prompts.</sub><br><br>
+<sub>Prompt engineering studio for AI image generation with 60+ curated art styles, a Recipe Stack system for layering up to 8 effects, target model selection, and full prompt history.</sub><br><br>
 <a href="https://styleyes.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
 <a href="https://github.com/SeanVasey/StyleyeS"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
 </td>
@@ -88,7 +90,7 @@ Music production tools, interactive instruments, and audio experiences. Building
 <img src="assets/placeholders/filephile.svg" width="280" alt="FilePhile" /><br>
 <strong>FilePhile</strong>
 </a><br>
-<sub>File generation studio for creating, editing, and exporting documents. Supports TXT, Markdown, JSON, CSV, HTML and more—all in-browser.</sub><br><br>
+<sub>Browser-based editor and file generation studio with 30+ export formats, syntax highlighting, regex find & replace, 50-level undo/redo, Zen Mode, and auto-save.</sub><br><br>
 <a href="https://filephile.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
 <a href="https://github.com/SeanVasey/FilePhile"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
 </td>
@@ -100,7 +102,7 @@ Music production tools, interactive instruments, and audio experiences. Building
 <img src="assets/placeholders/resourcery.svg" width="280" alt="reSOURCERY" /><br>
 <strong>reSOURCERY</strong>
 </a><br>
-<sub>Fast media extraction and conversion tool. Pull audio and video from web sources, convert between formats, and download—no installs needed.</sub><br><br>
+<sub>Client-side audio extraction and conversion powered by FFmpeg.wasm. Upload video/audio, auto-detect tempo, key, and metadata, then export to FLAC, WAV, MP3, or AAC.</sub><br><br>
 <a href="https://resourcery.vercel.app"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
 <a href="https://github.com/SeanVasey/reSOURCERY"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
 </td>
@@ -118,7 +120,7 @@ Music production tools, interactive instruments, and audio experiences. Building
 <img src="assets/placeholders/dullah80s.svg" width="280" alt="DULLAH80s" /><br>
 <strong>DULLAH80s</strong>
 </a><br>
-<sub>Mobile-ready 80s drum synthesizer and step sequencer. Classic drum machine sounds with a modern interface—play, sequence, and perform right in the browser.</sub><br><br>
+<sub>16-step sequencer with 16 percussion instruments, 4 pattern banks, swing control, live pads, reverb/delay effects, and a neon glassmorphism UI—all via Web Audio API.</sub><br><br>
 <a href="https://seanvasey.github.io/DULLAH80s"><img src="https://img.shields.io/badge/▶_LIVE-0ef0ff?style=flat-square&labelColor=0d1520" alt="Live"></a>
 <a href="https://github.com/SeanVasey/DULLAH80s"><img src="https://img.shields.io/badge/repo-2ec4b6?style=flat-square&labelColor=0d1520&logo=github&logoColor=fff" alt="Repo"></a>
 </td>
@@ -135,6 +137,8 @@ Music production tools, interactive instruments, and audio experiences. Building
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=fff)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=fff)
 ![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=fff)
+![Web Audio API](https://img.shields.io/badge/Web_Audio_API-4A90D9?style=for-the-badge&logo=webaudio&logoColor=fff)
+![FFmpeg](https://img.shields.io/badge/FFmpeg.wasm-007808?style=for-the-badge&logo=ffmpeg&logoColor=fff)
 ![Vercel](https://img.shields.io/badge/Vercel-000?style=for-the-badge&logo=vercel&logoColor=fff)
 ![GitHub Pages](https://img.shields.io/badge/GitHub_Pages-222?style=for-the-badge&logo=github&logoColor=fff)
 

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,21 +1,129 @@
-<svg width="1200" height="320" viewBox="0 0 1200 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="1200" height="340" viewBox="0 0 1200 340" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="320" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0b0f14"/>
-      <stop offset="0.55" stop-color="#101821"/>
-      <stop offset="1" stop-color="#0b0f14"/>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="340" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#080c12"/>
+      <stop offset="0.3" stop-color="#0d1520"/>
+      <stop offset="0.7" stop-color="#101d2e"/>
+      <stop offset="1" stop-color="#080c12"/>
     </linearGradient>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#10c7d8"/>
+      <stop offset="0" stop-color="#0ef0ff"/>
+      <stop offset="0.5" stop-color="#10c7d8"/>
       <stop offset="1" stop-color="#2ec4b6"/>
     </linearGradient>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f0c040"/>
+      <stop offset="1" stop-color="#e0a030"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <clipPath id="bannerClip">
+      <rect width="1200" height="340" rx="0"/>
+    </clipPath>
   </defs>
-  <rect width="1200" height="320" fill="url(#bg)"/>
-  <circle cx="110" cy="110" r="80" fill="url(#accent)" opacity="0.18"/>
-  <circle cx="1060" cy="60" r="120" fill="url(#accent)" opacity="0.12"/>
-  <circle cx="980" cy="250" r="90" fill="url(#accent)" opacity="0.18"/>
-  <path d="M80 250C180 190 260 180 360 200C440 215 520 250 620 240C740 226 820 160 930 150" stroke="url(#accent)" stroke-width="3" opacity="0.5"/>
-  <text x="80" y="140" fill="#e6f7ff" font-size="44" font-weight="700" font-family="'Inter', 'Segoe UI', sans-serif">Sean Vasey</text>
-  <text x="80" y="185" fill="#9bdbe5" font-size="20" font-weight="600" font-family="'Inter', 'Segoe UI', sans-serif">VASEY/AI • Vasey Multimedia • AI + Media Development</text>
-  <text x="80" y="225" fill="#7fbfca" font-size="16" font-weight="500" font-family="'Inter', 'Segoe UI', sans-serif">Creative tooling • Prompt engineering • Audio/visual experiences</text>
+
+  <g clip-path="url(#bannerClip)">
+    <!-- Background -->
+    <rect width="1200" height="340" fill="url(#bg)"/>
+
+    <!-- Subtle grid pattern -->
+    <g opacity="0.04" stroke="#0ef0ff" stroke-width="0.5">
+      <line x1="0" y1="40" x2="1200" y2="40"/>
+      <line x1="0" y1="80" x2="1200" y2="80"/>
+      <line x1="0" y1="120" x2="1200" y2="120"/>
+      <line x1="0" y1="160" x2="1200" y2="160"/>
+      <line x1="0" y1="200" x2="1200" y2="200"/>
+      <line x1="0" y1="240" x2="1200" y2="240"/>
+      <line x1="0" y1="280" x2="1200" y2="280"/>
+      <line x1="0" y1="320" x2="1200" y2="320"/>
+      <line x1="100" y1="0" x2="100" y2="340"/>
+      <line x1="200" y1="0" x2="200" y2="340"/>
+      <line x1="300" y1="0" x2="300" y2="340"/>
+      <line x1="400" y1="0" x2="400" y2="340"/>
+      <line x1="500" y1="0" x2="500" y2="340"/>
+      <line x1="600" y1="0" x2="600" y2="340"/>
+      <line x1="700" y1="0" x2="700" y2="340"/>
+      <line x1="800" y1="0" x2="800" y2="340"/>
+      <line x1="900" y1="0" x2="900" y2="340"/>
+      <line x1="1000" y1="0" x2="1000" y2="340"/>
+      <line x1="1100" y1="0" x2="1100" y2="340"/>
+    </g>
+
+    <!-- Decorative geometric elements -->
+    <circle cx="1050" cy="70" r="140" fill="url(#accent)" opacity="0.06"/>
+    <circle cx="1050" cy="70" r="90" stroke="url(#accent)" stroke-width="1" fill="none" opacity="0.12"/>
+    <circle cx="150" cy="280" r="100" fill="url(#accent)" opacity="0.05"/>
+    <circle cx="150" cy="280" r="60" stroke="url(#accent)" stroke-width="1" fill="none" opacity="0.08"/>
+
+    <!-- Circuit-like decorative lines -->
+    <g opacity="0.15" stroke="url(#accent)" stroke-width="1.5" fill="none">
+      <path d="M0 260 H200 L240 220 H380"/>
+      <circle cx="380" cy="220" r="3" fill="#0ef0ff"/>
+      <path d="M820 300 H950 L980 270 H1100 L1130 240 H1200"/>
+      <circle cx="950" cy="300" r="3" fill="#0ef0ff"/>
+      <circle cx="1100" cy="270" r="3" fill="#0ef0ff"/>
+    </g>
+
+    <!-- Accent line top -->
+    <rect x="0" y="0" width="1200" height="3" fill="url(#accent)" opacity="0.7"/>
+
+    <!-- Main text block -->
+    <text x="80" y="105" fill="#ffffff" font-size="52" font-weight="800" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" letter-spacing="-1">Sean Vasey</text>
+
+    <!-- Tagline with separator dots -->
+    <g filter="url(#softglow)">
+      <text x="80" y="148" fill="#0ef0ff" font-size="18" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" letter-spacing="2">
+        VASEY/AI
+      </text>
+    </g>
+    <circle cx="205" cy="143" r="3" fill="#0ef0ff" opacity="0.5"/>
+    <text x="220" y="148" fill="#7fbfca" font-size="18" font-weight="500" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" letter-spacing="1">
+      Vasey Multimedia
+    </text>
+
+    <!-- Description -->
+    <text x="80" y="195" fill="#b0d4dc" font-size="15" font-weight="400" font-family="'Inter', 'Segoe UI', system-ui, sans-serif">
+      AI-powered creative tools · Prompt engineering · Media utilities
+    </text>
+
+    <!-- Tech pills -->
+    <g transform="translate(80, 220)">
+      <rect x="0" y="0" width="80" height="26" rx="13" fill="#0ef0ff" opacity="0.12" stroke="#0ef0ff" stroke-width="0.8" stroke-opacity="0.3"/>
+      <text x="40" y="17" fill="#8de8f0" font-size="11" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">AI / LLM</text>
+
+      <rect x="92" y="0" width="90" height="26" rx="13" fill="#0ef0ff" opacity="0.12" stroke="#0ef0ff" stroke-width="0.8" stroke-opacity="0.3"/>
+      <text x="137" y="17" fill="#8de8f0" font-size="11" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">JavaScript</text>
+
+      <rect x="194" y="0" width="90" height="26" rx="13" fill="#0ef0ff" opacity="0.12" stroke="#0ef0ff" stroke-width="0.8" stroke-opacity="0.3"/>
+      <text x="239" y="17" fill="#8de8f0" font-size="11" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">TypeScript</text>
+
+      <rect x="296" y="0" width="56" height="26" rx="13" fill="#0ef0ff" opacity="0.12" stroke="#0ef0ff" stroke-width="0.8" stroke-opacity="0.3"/>
+      <text x="324" y="17" fill="#8de8f0" font-size="11" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">PWA</text>
+
+      <rect x="364" y="0" width="70" height="26" rx="13" fill="#0ef0ff" opacity="0.12" stroke="#0ef0ff" stroke-width="0.8" stroke-opacity="0.3"/>
+      <text x="399" y="17" fill="#8de8f0" font-size="11" font-weight="600" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">Audio</text>
+    </g>
+
+    <!-- Right side: project count badge -->
+    <g transform="translate(920, 100)">
+      <rect x="0" y="0" width="200" height="80" rx="12" fill="#0d1520" stroke="url(#accent)" stroke-width="1" opacity="0.8"/>
+      <text x="100" y="35" fill="#0ef0ff" font-size="32" font-weight="800" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">6</text>
+      <text x="100" y="58" fill="#7fbfca" font-size="13" font-weight="500" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">LIVE PROJECTS</text>
+    </g>
+
+    <!-- Bottom accent line -->
+    <rect x="0" y="337" width="1200" height="3" fill="url(#accent)" opacity="0.7"/>
+  </g>
 </svg>

--- a/assets/divider.svg
+++ b/assets/divider.svg
@@ -1,0 +1,15 @@
+<svg width="800" height="12" viewBox="0 0 800 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="divGrad" x1="0" y1="6" x2="800" y2="6" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0ef0ff" stop-opacity="0"/>
+      <stop offset="0.15" stop-color="#0ef0ff" stop-opacity="0.6"/>
+      <stop offset="0.5" stop-color="#10c7d8" stop-opacity="1"/>
+      <stop offset="0.85" stop-color="#2ec4b6" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#2ec4b6" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <line x1="0" y1="6" x2="800" y2="6" stroke="url(#divGrad)" stroke-width="1.5"/>
+  <circle cx="400" cy="6" r="3" fill="#0ef0ff" opacity="0.8"/>
+  <circle cx="380" cy="6" r="1.5" fill="#10c7d8" opacity="0.5"/>
+  <circle cx="420" cy="6" r="1.5" fill="#2ec4b6" opacity="0.5"/>
+</svg>

--- a/assets/footer.svg
+++ b/assets/footer.svg
@@ -1,0 +1,26 @@
+<svg width="1200" height="120" viewBox="0 0 1200 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="fbg" x1="0" y1="0" x2="1200" y2="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#080c12"/>
+      <stop offset="0.5" stop-color="#0d1520"/>
+      <stop offset="1" stop-color="#080c12"/>
+    </linearGradient>
+    <linearGradient id="faccent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ef0ff"/>
+      <stop offset="1" stop-color="#2ec4b6"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="120" fill="url(#fbg)"/>
+  <rect x="0" y="0" width="1200" height="2" fill="url(#faccent)" opacity="0.5"/>
+
+  <!-- Circuit decoration -->
+  <g opacity="0.1" stroke="url(#faccent)" stroke-width="1" fill="none">
+    <path d="M0 80 H150 L170 60 H300"/>
+    <path d="M900 80 H1050 L1070 60 H1200"/>
+  </g>
+
+  <text x="600" y="55" fill="#7fbfca" font-size="13" font-weight="500" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle" letter-spacing="3">BUILT WITH INTENTION</text>
+  <text x="600" y="80" fill="#4a7a85" font-size="11" font-weight="400" font-family="'Inter', 'Segoe UI', system-ui, sans-serif" text-anchor="middle">sean@vaseyai.com · Des Moines, IA</text>
+
+  <rect x="0" y="118" width="1200" height="2" fill="url(#faccent)" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
- Replace template-style README with a visually compelling, content-rich profile
- New hero banner SVG with circuit-board aesthetic, tech pills, and project counter
- Add section divider SVG with gradient accent line and dot details
- Add footer SVG with location and contact branding
- Replace placeholder table with card-style 3-column project grid with live/repo badges
- Add all social links (X, Instagram, SoundCloud, LinkedIn, portfolio)
- Update VASEY/AI and Vasey Multimedia enterprise descriptions with real focus areas
- Add GitHub stats cards, tech stack badges, and current focus section
- Remove all [placeholder] content and fill with actual information

https://claude.ai/code/session_01UHNo6RenXirKznvgpyV3iq