### PR TITLE
docs: cut v1.0.0 release in CHANGELOG and add summary.yml to MANIFEST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-13
+
 ### Added
 - Added curated brand, portrait, and app placard assets under `assets/brand`, `assets/portraits`, and `assets/placards`.
 - Added repository baseline files: `.editorconfig`, `.gitignore`, `.env.example`, and `docs/MANIFEST.md`.
 - Added GitHub Actions CI workflow for markdown linting and README link checks.
+- Added GitHub Actions AI issue summarization workflow (`summary.yml`).
 
 ### Changed
 - Redesigned `README.md` header to use uploaded Vasey Multimedia banner and renamed portrait.
 - Replaced generic SVG app card placeholders with uploaded app placards where available.
 - Expanded documentation structure with setup, architecture, licensing notes, and app/skill flags.
 - Improved `SECURITY.md` with clearer vulnerability reporting and handling expectations.
+
+[1.0.0]: https://github.com/SeanVasey/SeanVasey/releases/tag/v1.0.0

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -18,6 +18,7 @@
 ## Automation
 
 - `.github/workflows/ci.yml` — Markdown quality CI checks on PR and push.
+- `.github/workflows/summary.yml` — AI-powered issue summarization on new issue creation.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` block in `CHANGELOG.md` to a proper `[1.0.0] - 2026-06-13` versioned release entry, adds a new empty `[Unreleased]` section above it per [Keep a Changelog](https://keepachangelog.com/) convention, and appends the `summary.yml` workflow to the **Added** list (was missing from the original entries).

Also adds the `summary.yml` workflow entry to the **Automation** section in `docs/MANIFEST.md` so it stays in sync with the changelog and wiki.

Link to Devin session: https://app.devin.ai/sessions/91b53871465842059dea482771e893e0
Requested by: @SeanVasey